### PR TITLE
fix: poetry installation method

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install poetry requirements
         if: ${{ steps.package_manager.outputs.value == 'poetry' }}
         run: >
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - &&
+          curl -sSL https://install.python-poetry.org | python - &&
           source $HOME/.poetry/env &&
           poetry install
 


### PR DESCRIPTION
As mentioned in the [doc](https://python-poetry.org/docs/#installation) the `get-poetry.py` installation method is deprecated.