### PR TITLE
exclude .git directory from TODO linter

### DIFF
--- a/.github/actions/lint-todos/action.yml
+++ b/.github/actions/lint-todos/action.yml
@@ -12,4 +12,4 @@ runs:
   steps:
     - name: Check template TODOs are resolved
       shell: bash
-      run: '! grep -rin "${{ inputs.placeholder }}" ./'
+      run: '! grep -rin --exclude-dir=.git "${{ inputs.placeholder }}" ./'


### PR DESCRIPTION
because of new hook example