### PR TITLE
Updated codeql-action to v3.

### DIFF
--- a/.github/actions/lint-security/action.yml
+++ b/.github/actions/lint-security/action.yml
@@ -33,11 +33,11 @@ runs:
           .semgrep
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       if: ${{ always() && !github.event.repository.private && inputs.skip-codeql == 'false' }}
       with:
         languages: ${{ inputs.languages }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       if: ${{ always() && !github.event.repository.private && inputs.skip-codeql == 'false' }}

--- a/.github/actions/lint-security/action.yml
+++ b/.github/actions/lint-security/action.yml
@@ -33,11 +33,11 @@ runs:
           .semgrep
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@6e4b8622b82fab3c6ad2a7814fad1effc7615bc8 # v3.28.4
+      uses: github/codeql-action/init@ee117c905ab18f32fa0f66c2fe40ecc8013f3e04 # v3.28.4
       if: ${{ always() && !github.event.repository.private && inputs.skip-codeql == 'false' }}
       with:
         languages: ${{ inputs.languages }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@6e4b8622b82fab3c6ad2a7814fad1effc7615bc8 # v3.28.4
+      uses: github/codeql-action/analyze@ee117c905ab18f32fa0f66c2fe40ecc8013f3e04 # v3.28.4
       if: ${{ always() && !github.event.repository.private && inputs.skip-codeql == 'false' }}

--- a/.github/actions/lint-security/action.yml
+++ b/.github/actions/lint-security/action.yml
@@ -33,11 +33,11 @@ runs:
           .semgrep
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@6e4b8622b82fab3c6ad2a7814fad1effc7615bc8 # v3.28.4
       if: ${{ always() && !github.event.repository.private && inputs.skip-codeql == 'false' }}
       with:
         languages: ${{ inputs.languages }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@6e4b8622b82fab3c6ad2a7814fad1effc7615bc8 # v3.28.4
       if: ${{ always() && !github.event.repository.private && inputs.skip-codeql == 'false' }}


### PR DESCRIPTION
## Why we have to update

Taken from [github.blog](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/):

> On December 13, 2023, we released CodeQL Action v3, which runs on the Node.js 20 runtime. In January 2024, we announced that CodeQL Action v2 would be retired at the same time as GitHub Enterprise Server (GHES) 3.11. This retirement period has elapsed and CodeQL Action v2 is now discontinued. It will no longer be updated or supported, and while we will not be deleting it except in the case of a security vulnerability, workflows using it may eventually break. New CodeQL analysis capabilities will only be available to users of v3.

Discord [thread](https://discord.com/channels/761182643269795850/1329776435744735274).

**Upd.**

I've replaced v3 tag by the hash from the [latest](https://github.com/github/codeql-action/tags) version v3.28.4.

## What were done

The `github/codeql-action/init` and `github/codeql-action/analyze` were updated to v3. 

@choooze, @amarao plz review it.